### PR TITLE
Add carlanton/m3u8-parser

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -1545,6 +1545,12 @@
             "description": "DASH MPD tools for Java.",
             "title": "carlanton/mpd-tools"
         },
+        {                                                                                                         
+            "category": "hls",                                                                                    
+            "homepage": "https://github.com/carlanton/m3u8-parser",                                               
+            "description": "HLS compliant m3u8 parser for Java.",                                                        
+            "title": "carlanton/m3u8-parser"                                                                      
+        },
         {
             "category": [
                 "tools",


### PR DESCRIPTION
Adding another manifest parser for java. It seems to be used by HLS publishers here and there.