### PR TITLE
Add libvlc-go

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -2409,6 +2409,12 @@
             "title": "videolan/libvlcsharp"
         },
         {
+            "category": "players",
+            "homepage": "https://github.com/adrg/libvlc-go",
+            "description": "Go bindings for libVLC and high-level media player interface.",
+            "title": "adrg/libvlc-go"
+        },
+        {
             "category": "tools",
             "homepage": "https://github.com/DSRCorporation/imf-conversion",
             "description": "NF IMF media conversion utility allows to handle flat file creation from a specified CPL within the IMF package - DSRCorporation/imf-conversion",


### PR DESCRIPTION
Added libvlc-go: https://github.com/adrg/libvlc-go.

Please take a look the repository and maybe consider adding it if you think it's suitable. There does not seem to be any video player library for the Go language in the list.