### PR TITLE
fix: update go HLS lib

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -13418,9 +13418,9 @@
       "category": [
         "hls"
       ],
-      "description": "Parser and generator of M3U8-playlists for Apple HLS. Library for Go language. :cinema: - grafov/m3u8",
-      "homepage": "https://github.com/grafov/m3u8",
-      "title": "grafov/m3u8",
+      "description": "Parser and generator of M3U8-playlists for Apple HLS. Library for Go language. :cinema: - eyevinn/hls-m3u8",
+      "homepage": "https://github.com/Eyevinn/hls-m3u8",
+      "title": "eyevinn/hls-m3u8",
       "tags": [
         "library",
         "go",


### PR DESCRIPTION
The go library https://github.com/grafov/m3u8 has stopped development and is no longer being updated.
From the project README:
>Important
The project support suspended and code moved to read only archive. https://github.com/grafov/m3u8/issues/225
The project has a successor: https://github.com/Eyevinn/hls-m3u8.
I encourage you to migrate to the new library, [Eyevinn/hls-m3u8](https://github.com/Eyevinn/hls-m3u8), as HLS continues to evolve and the new library supports newer features.

I think the awesome-video repo should be updated to reflect this.

## Summary by Sourcery

Documentation:
- Replace deprecated grafov/m3u8 library entry with maintained Eyevinn/hls-m3u8 in contents.json