### PR TITLE
Add Muxide: Pure Rust MP4 muxer for recording applications

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -1333,6 +1333,22 @@
       ]
     },
     {
+      "title": "Muxide",
+      "description": "Muxide is a high-performance MP4 muxing and demuxing library written in Rust. It provides fast, memory-efficient processing of MP4 containers with support for fragmented MP4, streaming, and advanced video processing features. Perfect for applications requiring low-latency video manipulation and streaming.",
+      "homepage": "https://github.com/Michael-A-Kuykendall/muxide",
+      "category": [
+        "general-tools"
+      ],
+      "tags": [
+        "mp4",
+        "muxing",
+        "demuxing",
+        "video-processing",
+        "rust",
+        "streaming"
+      ]
+    },
+    {
       "title": "Nimble Streamer DRM",
       "description": "Nimble Streamer is a media server that supports Digital Rights Management (DRM) for various encryption providers, including Widevine, PlayReady, and FairPlay. It offers features like live streaming encryption, DVR encryption, and VOD content encryption, ensuring secure content delivery across multiple platforms.",
       "homepage": "https://softvelum.com/nimble/drm/",


### PR DESCRIPTION
Adding Muxide, a zero-dependency pure-Rust MP4 muxer for recording applications, to the General Tools section.

Muxide provides:

• Takes correctly-timestamped, already-encoded audio/video frames
• Produces standards-compliant, immediately-playable MP4 files
• Pure Rust implementation with zero runtime dependencies
• No FFmpeg required - handles the last mile from encoder to playable MP4
• Supports H.264, H.265, AV1 video codecs and AAC, Opus audio codecs
• Fast-start ready MP4 output

Repository: https://github.com/Michael-A-Kuykendall/muxide
Category: General Tools (video processing utilities)
Tags: mp4, muxing, video-processing, rust, recording, encoder

This fits perfectly as a specialized MP4 muxing tool for video recording pipelines.

## Summary by Sourcery

New Features:

• Include Muxide as a new general-purpose MP4 video processing tool entry in contents.json.