### PR TITLE
Add JellySubtitles to Subtitles & Captions

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -30619,6 +30619,21 @@
         "video standards",
         "encoding"
       ]
+    },
+    {
+      "title": "GeiserX/JellySubtitles",
+      "description": "Docker-based tool that automatically downloads subtitles for Jellyfin media libraries, monitoring your library and fetching missing subtitles from OpenSubtitles and other providers.",
+      "homepage": "https://github.com/GeiserX/JellySubtitles",
+      "category": [
+        "subtitles-captions"
+      ],
+      "tags": [
+        "subtitles",
+        "Jellyfin",
+        "Docker",
+        "OpenSubtitles",
+        "automation"
+      ]
     }
   ],
   "ios_app_link": "https://apps.apple.com/app/awesome-video/id1234567890"


### PR DESCRIPTION
## Summary

- Adds [JellySubtitles](https://github.com/GeiserX/JellySubtitles) to the **Subtitles & Captions** category in `contents.json`.
- JellySubtitles is a Docker-based tool that automatically downloads subtitles for Jellyfin media libraries. It monitors your Jellyfin library and fetches missing subtitles from OpenSubtitles and other providers.
- Licensed under GPL-3.0.

## Why it should be included

- Performs a useful, specific function: automated subtitle downloading for Jellyfin users.
- Open source (GPL-3.0), well-documented with Docker deployment instructions.
- Fills a gap in the list — no other Jellyfin-specific subtitle automation tool is currently listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- List JellySubtitles in the Subtitles & Captions section of contents.json as a Docker-based subtitle downloader for Jellyfin libraries.