### PR TITLE
Add WhisperSubs to Subtitles & Captions

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -30621,9 +30621,9 @@
       ]
     },
     {
-      "title": "jelly-subtitles",
+      "title": "WhisperSubs",
       "description": "Jellyfin plugin for local AI-powered subtitle generation using Whisper, with all processing on your server.",
-      "homepage": "https://github.com/GeiserX/jelly-subtitles",
+      "homepage": "https://github.com/GeiserX/whisper-subs",
       "category": [
         "subtitles-captions"
       ],

--- a/contents.json
+++ b/contents.json
@@ -30619,6 +30619,21 @@
         "video standards",
         "encoding"
       ]
+    },
+    {
+      "title": "jelly-subtitles",
+      "description": "Jellyfin plugin for local AI-powered subtitle generation using Whisper, with all processing on your server.",
+      "homepage": "https://github.com/GeiserX/jelly-subtitles",
+      "category": [
+        "subtitles-captions"
+      ],
+      "tags": [
+        "subtitles",
+        "Whisper",
+        "AI",
+        "Jellyfin",
+        "speech-to-text"
+      ]
     }
   ],
   "ios_app_link": "https://apps.apple.com/app/awesome-video/id1234567890"


### PR DESCRIPTION
## Summary
- Adds [WhisperSubs](https://github.com/GeiserX/whisper-subs) to the Subtitles & Captions category in `contents.json`.
- Jellyfin plugin for local AI-powered subtitle generation using Whisper, with all processing on your server.
- Licensed under GPL-3.0.