### PR TITLE
Add Tight Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ PLEASE DO NOT UPDATE THIS FILE, UPDATE CONTENTS.JSON INSTEAD. THANK YOU :-)
 *Complete software suites for non-linear video editing.*
 [back to top](#readme) 
 
-* [jliljebl/flowblade](https://github.com/jliljebl/flowblade)  - A tool or resource for non-linear-editing-suites.
+* [jliljebl/flowblade](https://github.com/jliljebl/flowblade)  - A tool or resource for non-linear editing suites.
 * [Tight Studio](https://tight.studio/)  - Screen recorder and video editor for macOS with auto-zoom, captions, AI voiceover, and background music. Uses WebGPU for GPU-accelerated compositing.
 
 ### Subtitle & Caption Tools

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ PLEASE DO NOT UPDATE THIS FILE, UPDATE CONTENTS.JSON INSTEAD. THANK YOU :-)
 [back to top](#readme) 
 
 * [jliljebl/flowblade](https://github.com/jliljebl/flowblade)  - A tool or resource for non-linear-editing-suites.
+* [Tight Studio](https://tight.studio/)  - Screen recorder and video editor for macOS with auto-zoom, captions, AI voiceover, and background music. Uses WebGPU for GPU-accelerated compositing.
 
 ### Subtitle & Caption Tools
 *Tools for working with subtitles and captions in video.*


### PR DESCRIPTION
## Summary

Adds [Tight Studio](https://tight.studio/) to the **Non-linear Editing Suites** section under Video Editing & Processing Tools.

Tight Studio is a screen recorder and video editor for macOS that produces polished product demos, tutorials, and presentations. Key features include auto-zoom, captions, AI voiceover, and background music. It uses WebGPU for GPU-accelerated video compositing and FFmpeg for export. Freemium pricing model.

## Summary by Sourcery

Documentation:
- Document Tight Studio as a macOS screen recorder and video editor with GPU-accelerated compositing and AI-assisted features in the non-linear editing suites list.