### PR TITLE
Add hevc.js — HEVC WASM decoder with dash.js plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,6 +645,7 @@ PLEASE DO NOT UPDATE THIS FILE, UPDATE CONTENTS.JSON INSTEAD. THANK YOU :-)
 * [Dash-Industry-Forum/dash-live-source-simulator](https://github.com/Dash-Industry-Forum/dash-live-source-simulator)  - DASH live source simulator providing reference live content. - Dash-Industry-Forum/dash-live-source-simulator
 * [Dash-Industry-Forum/dash.js](https://github.com/Dash-Industry-Forum/dash.js)  - A reference client implementation for the playback of MPEG DASH via Javascript and compliant browsers. - Dash-Industry-Forum/dash.js
 * [Dash-Industry-Forum/media-tools](https://github.com/Dash-Industry-Forum/media-tools)  - A collection of tools for analyzing, handling, and creating media and media containers - Dash-Industry-Forum/media-tools
+* [privaloops/hevc.js](https://github.com/privaloops/hevc.js)  - HEVC/H.265 decoder in WebAssembly with a drop-in dash.js plugin. Transcodes HEVC to H.264 client-side via WebCodecs for browsers without native HEVC support.
 * [Eyevinn/docker-2dash](https://github.com/Eyevinn/docker-2dash)  - A Docker container to pre-package MPEG DASH on demand content - Eyevinn/docker-2dash
 * [Eyevinn/docker-dash-packager](https://github.com/Eyevinn/docker-dash-packager)  - Open source MPEG DASH packager for live and VOD.
 * [MPEG DASH Sample Content Bento4](http://www.bento4.com/developers/dash/dash-sample-content/)  - Bento4 offers MPEG-DASH sample content for developers to test and validate their DASH implementations.

--- a/contents.json
+++ b/contents.json
@@ -30619,6 +30619,25 @@
         "video standards",
         "encoding"
       ]
+    },
+    {
+      "category": [
+        "dash",
+        "hevc"
+      ],
+      "homepage": "https://github.com/privaloops/hevc.js",
+      "description": "HEVC/H.265 decoder in WebAssembly with a drop-in dash.js plugin. Transcodes HEVC to H.264 client-side via WebCodecs for browsers without native HEVC support.",
+      "title": "privaloops/hevc.js",
+      "tags": [
+        "webassembly",
+        "hevc",
+        "h265",
+        "dash",
+        "transcoding",
+        "javascript",
+        "wasm",
+        "video-codec"
+      ]
     }
   ],
   "ios_app_link": "https://apps.apple.com/app/awesome-video/id1234567890"


### PR DESCRIPTION
Adds [hevc.js](https://github.com/privaloops/hevc.js) to the DASH Tools section.

hevc.js is an HEVC/H.265 decoder compiled to WebAssembly with a drop-in plugin for dash.js. It transcodes HEVC to H.264 client-side via WebCodecs for browsers without native HEVC support.

- 236KB WASM, 1080p realtime transcoding
- MIT license
- npm: `@hevcjs/dashjs-plugin`
- Live demo: https://hevcjs.dev/demo/dash.html

## Summary by Sourcery

Documentation:
- Document hevc.js as a DASH tool providing client-side HEVC-to-H.264 transcoding via WebAssembly and WebCodecs.