### PR TITLE
Add rav2d - memory-safe AV2 video decoder in Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -1211,6 +1211,7 @@ PLEASE DO NOT UPDATE THIS FILE, UPDATE CONTENTS.JSON INSTEAD. THANK YOU :-)
 [back to top](#readme) 
 
 * [videolan/dav1d](https://code.videolan.org/videolan/dav1d)  - dav1d is the fastest AV1 decoder on all platforms.
+* [stukenov/rav2d](https://github.com/stukenov/rav2d)  - Memory-safe AV2 video decoder in Rust, ported from dav2d. Assembly DSP via FFI, all C decoder logic in safe Rust.
 
 ## DRM, Security & Content Protection
 *Resources and tools related to drm, security & content protection.*


### PR DESCRIPTION
Adding [rav2d](https://github.com/stukenov/rav2d) to the Software Codecs section.

**rav2d** is a complete Rust port of dav2d (AV2 video decoder):
- 47K+ lines of Rust, 786 tests passing
- All C decoder logic ported to safe Rust
- Assembly DSP kernels shared via FFI
- Full pipeline: OBU parsing, MSAC, block decode, deblock, CDEF, loop restoration, film grain, motion comp, inverse transforms, threading

Same approach as rav1d (AV1 Rust port). Licensed BSD 2-Clause.

## Summary by Sourcery

Documentation:
- List the rav2d Rust AV2 decoder under Software Codecs in the README.