### PR TITLE
Add SubLingo to Subtitle & Caption Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1347,6 +1347,7 @@
 - [estliberitas/node-thumbnails-webvtt](https://github.com/estliberitas/node-thumbnails-webvtt) - Video thumbnail generator generating WebVTT spec file - estliberitas/node-thumbnails-webvtt.
 - [shawnsky/extract-subtitles](https://github.com/shawnsky/extract-subtitles) - Extract Subtitles From Video.
 - [statsbiblioteket/tv-subtitle-extraction](https://github.com/statsbiblioteket/tv-subtitle-extraction) - System for extraction of subtitles from TV broadcasts. - statsbiblioteket/tv-subtitle-extraction.
+- [SubLingo](https://sublingo.cc) - Free in-browser tool to translate SRT and VTT subtitles into 100+ languages while keeping every timecode exact, plus SRT/VTT conversion, timing shift, FPS, and cleanup utilities.
 
 #### Subtitles & Captions
 


### PR DESCRIPTION
Adds **SubLingo** to the Subtitle & Caption Tools section.

- URL: https://sublingo.cc
- A free, in-browser tool that translates SRT and VTT subtitle files into 100+ languages while preserving every timecode exactly. Also includes SRT/VTT conversion, timing shift/sync, FPS, and cleanup utilities.
- No signup, runs in the browser, actively maintained.

Single entry matching the existing one-line format in that section.

## Summary by Sourcery

Documentation:
- Document the SubLingo web tool alongside existing subtitle and caption utilities in the README.