### PR TITLE
Add TimedSubs subtitle checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1695,6 +1695,7 @@ The solution supports:
 - [estliberitas/node-thumbnails-webvtt](https://github.com/estliberitas/node-thumbnails-webvtt) - Video thumbnail generator generating WebVTT spec file - estliberitas/node-thumbnails-webvtt.
 - [shawnsky/extract-subtitles](https://github.com/shawnsky/extract-subtitles) - Extract Subtitles From Video.
 - [statsbiblioteket/tv-subtitle-extraction](https://github.com/statsbiblioteket/tv-subtitle-extraction) - System for extraction of subtitles from TV broadcasts. - statsbiblioteket/tv-subtitle-extraction.
+- [TimedSubs](https://timedsubs.com/en/tools/subtitle-checker) - Browser-local SRT/VTT checker with safe line-wrap repair.
 
 #### Subtitles & Captions
 


### PR DESCRIPTION
Adds TimedSubs to Subtitle & Caption Tools.

Disclosure: I am the maker of TimedSubs.

Why it fits:
- Browser-local SRT/VTT checker.
- Flags timing, overlap, line length, and reading-speed issues.
- Can safely repair long line breaks without changing timestamps.
- No upload or login required for the free checker.

## Summary by Sourcery

Documentation:
- Document TimedSubs as a browser-local SRT/VTT checker with safe line-wrap repair in the Subtitle & Caption tools list.