### PR TITLE
Add rtblint to Ads & QoE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1564,6 +1564,8 @@ The solution supports:
 
 ### Ads & QoE
 
+- [rtblint](https://github.com/aleksUIX/rtblint) - An open-source OpenRTB bid request validator and linter, checking requests against the IAB Tech Lab OpenRTB spec (2.0 through 3.0) for malformed JSON, missing fields, and type mismatches. Ships as a free browser tester, a Rust CLI, and an MCP server for AI agents.
+
 #### Quality & Testing
 
 - [bavc/qctools](https://github.com/bavc/qctools) - A tool or resource for quality-analysis-metrics.


### PR DESCRIPTION
Adds rtblint (https://github.com/aleksUIX/rtblint), an open-source OpenRTB bid request validator and linter, to the Ads & QoE section.

It checks bid requests against the IAB Tech Lab OpenRTB spec (2.0 through 3.0): malformed JSON, missing required fields, unknown/deprecated fields, type mismatches. It fits alongside zveloDB and the RTB/VAST tooling already referenced elsewhere in this list, as a validation tool for the CTV/video programmatic bidding side of the stack.

Disclosure: I maintain rtblint. It's about 2 months old and under active development (Rust core, WASM browser tester, CLI, MCP server), so treat the "actively maintained" bar accordingly.

## Summary by Sourcery

Documentation:
- Document rtblint as an OpenRTB bid request validator and linter alongside existing Ads & QoE tooling.