### PR TITLE
Add What the GIF

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -30619,6 +30619,21 @@
         "video standards",
         "encoding"
       ]
+    },
+    {
+      "title": "What the GIF",
+      "homepage": "https://whatthegif.com",
+      "description": "A free video to GIF converter and editor that runs entirely in the browser, so video files are never uploaded to a server. It offers frame-accurate trimming, stitching of up to three clips, timed text captions, cropping, and fps, size, and color controls, with no signup, watermark, or install.",
+      "category": [
+        "media-tools"
+      ],
+      "tags": [
+        "gif",
+        "video to gif",
+        "browser-based",
+        "client-side",
+        "editing"
+      ]
     }
   ],
   "ios_app_link": "https://apps.apple.com/app/awesome-video/id1234567890"


### PR DESCRIPTION
This adds What the GIF (https://whatthegif.com) to the Media Tools category in contents.json, per the contributing guide. It is a free video to GIF converter and editor that runs entirely in the browser (100% client side, video files are never uploaded to a server), with no signup, watermark, or install. It offers frame-accurate trimming, stitching of up to three clips, timed text captions, cropping, and fps, size, and color controls. Disclosure: I built this tool, and I am happy to adjust the description, category, or tags.

## Summary by Sourcery

New Features:
- List What the GIF as a new media tool for browser-based video-to-GIF conversion and editing in the catalog.