### PR TITLE
Add CreateFaceless resource

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -30619,6 +30619,20 @@
         "video standards",
         "encoding"
       ]
+    },
+    {
+      "title": "CreateFaceless",
+      "homepage": "https://createfaceless.com/en",
+      "description": "Generates faceless YouTube Shorts from script to visuals, voiceover, captions, cover, metadata, and exportable MP4 without requiring editing experience.",
+      "category": [
+        "media-tools"
+      ],
+      "tags": [
+        "AI",
+        "faceless video",
+        "video generation",
+        "YouTube Shorts"
+      ]
     }
   ],
   "ios_app_link": "https://apps.apple.com/app/awesome-video/id1234567890"


### PR DESCRIPTION
## Summary

- Add CreateFaceless to the generated-list source in `contents.json`
- Categorize it under media tools with AI, faceless video, video generation, and YouTube Shorts tags

## Why include it

CreateFaceless turns a short-form video idea into a complete faceless YouTube Short, including the script, visuals, voiceover, captions, cover, metadata, and exportable MP4. It is actively maintained and offers one free trial Short without requiring a credit card.

## Validation

- `contents.json` parses successfully
- The repository JSON schema validation passes
- https://createfaceless.com/en returns HTTP 200

Disclosure: I am the maker of CreateFaceless.

## Summary by Sourcery

New Features:
- Register CreateFaceless as a new faceless video generation tool in contents.json with appropriate categorization and tags.